### PR TITLE
avoid read-only mode runtime overhead with generics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2236,6 +2236,7 @@ version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-process",
+ "async-trait",
  "axum",
  "clap",
  "columnq",

--- a/roapi-http/Cargo.toml
+++ b/roapi-http/Cargo.toml
@@ -27,6 +27,7 @@ tower-http = { version = "0", features = ["cors"] }
 tower-layer = "0"
 tracing = "0"
 pin-project = "1"
+async-trait = "0"
 
 env_logger = "0"
 log = "0"

--- a/roapi-http/src/api/graphql.rs
+++ b/roapi-http/src/api/graphql.rs
@@ -7,10 +7,10 @@ use std::sync::Arc;
 use crate::api::{encode_record_batches, encode_type_from_hdr};
 use crate::error::ApiErrResp;
 
-use super::HandlerCtxType;
+use super::HandlerCtx;
 
-pub async fn post(
-    state: extract::Extension<Arc<HandlerCtxType>>,
+pub async fn post<H: HandlerCtx>(
+    state: extract::Extension<Arc<H>>,
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<impl IntoResponse, ApiErrResp> {

--- a/roapi-http/src/api/mod.rs
+++ b/roapi-http/src/api/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
 
+use async_trait::async_trait;
 use axum::body::Body;
 use axum::http::header;
 use axum::http::Response;
@@ -8,22 +9,22 @@ use axum::response::IntoResponse;
 use columnq::datafusion::arrow;
 use columnq::encoding;
 use columnq::encoding::ContentType;
-use columnq::ColumnQ;
 use columnq::error::ColumnQError;
 use columnq::error::QueryError;
 use columnq::table::TableSource;
+use columnq::ColumnQ;
 use log::info;
 use tokio::sync::RwLock;
 
 use crate::config::Config;
 use crate::error::ApiErrResp;
 
-pub struct HandlerContext {
+pub struct RawHandlerContext {
     pub cq: ColumnQ,
     // TODO: store pre serialized schema in handler context
 }
 
-impl HandlerContext {
+impl RawHandlerContext {
     pub async fn new(config: &Config) -> anyhow::Result<Self> {
         let mut cq = ColumnQ::new();
 
@@ -41,70 +42,120 @@ impl HandlerContext {
     }
 }
 
-pub enum HandlerCtxType {
-    RwLock(RwLock<HandlerContext>),
-    NoLock(HandlerContext),
+pub type ConcurrentHandlerContext = RwLock<RawHandlerContext>;
+
+#[async_trait]
+pub trait HandlerCtx: Send + Sync + 'static {
+    fn read_only_mode() -> bool;
+
+    async fn load_table(&self, table: &TableSource) -> Result<(), ColumnQError>;
+    // FIXME: avoid clone
+    async fn schema_map(&self) -> HashMap<String, arrow::datatypes::SchemaRef>;
+    async fn query_graphql(
+        &self,
+        query: &str,
+    ) -> Result<Vec<arrow::record_batch::RecordBatch>, QueryError>;
+    async fn query_sql(
+        &self,
+        query: &str,
+    ) -> Result<Vec<arrow::record_batch::RecordBatch>, QueryError>;
+    async fn query_rest_table(
+        &self,
+        table_name: &str,
+        params: &HashMap<String, String>,
+    ) -> Result<Vec<arrow::record_batch::RecordBatch>, QueryError>;
 }
 
-impl HandlerCtxType {
-    pub async fn load_table(&self, table: &TableSource) -> Result<(), ColumnQError> {
-        match self {
-            HandlerCtxType::RwLock(ctx) => {
-                let mut ctx = ctx.write().await;
-                ctx.cq.load_table(table).await
-            }
-            _ => Err(ColumnQError::Generic("Current is read only".to_string())),
-        }
+#[async_trait]
+impl HandlerCtx for RawHandlerContext {
+    #[inline]
+    fn read_only_mode() -> bool {
+        true
     }
 
-    pub async fn schema_map(&self) -> HashMap<String, arrow::datatypes::SchemaRef> {
-        match self {
-            HandlerCtxType::RwLock(ctx) => {
-                let ctx = ctx.read().await;
-                ctx.cq.schema_map().clone()
-            }
-            HandlerCtxType::NoLock(ctx) => ctx.cq.schema_map().clone(),
-        }
+    #[inline]
+    async fn load_table(&self, _table: &TableSource) -> Result<(), ColumnQError> {
+        Err(ColumnQError::Generic(
+            "Table update not supported in read only mode".to_string(),
+        ))
     }
 
-    pub async fn query_graphql(
+    #[inline]
+    async fn schema_map(&self) -> HashMap<String, arrow::datatypes::SchemaRef> {
+        self.cq.schema_map().clone()
+    }
+
+    #[inline]
+    async fn query_graphql(
         &self,
         query: &str,
     ) -> Result<Vec<arrow::record_batch::RecordBatch>, QueryError> {
-        match self {
-            HandlerCtxType::RwLock(ctx) => {
-                let ctx = ctx.read().await;
-                ctx.cq.query_graphql(query).await
-            }
-            HandlerCtxType::NoLock(ctx) => ctx.cq.query_graphql(query).await,
-        }
+        self.cq.query_graphql(query).await
     }
 
-    pub async fn query_sql(
+    #[inline]
+    async fn query_sql(
         &self,
         query: &str,
     ) -> Result<Vec<arrow::record_batch::RecordBatch>, QueryError> {
-        match self {
-            HandlerCtxType::RwLock(ctx) => {
-                let ctx = ctx.read().await;
-                ctx.cq.query_sql(query).await
-            }
-            HandlerCtxType::NoLock(ctx) => ctx.cq.query_sql(query).await,
-        }
+        self.cq.query_sql(query).await
     }
 
-    pub async fn query_rest_table(
+    #[inline]
+    async fn query_rest_table(
         &self,
         table_name: &str,
         params: &HashMap<String, String>,
     ) -> Result<Vec<arrow::record_batch::RecordBatch>, QueryError> {
-        match self {
-            HandlerCtxType::RwLock(ctx) => {
-                let ctx = ctx.read().await;
-                ctx.cq.query_rest_table(table_name, params).await
-            }
-            HandlerCtxType::NoLock(ctx) => ctx.cq.query_rest_table(table_name, params).await,
-        }
+        self.cq.query_rest_table(table_name, params).await
+    }
+}
+
+#[async_trait]
+impl HandlerCtx for ConcurrentHandlerContext {
+    #[inline]
+    fn read_only_mode() -> bool {
+        false
+    }
+
+    #[inline]
+    async fn load_table(&self, table: &TableSource) -> Result<(), ColumnQError> {
+        let mut ctx = self.write().await;
+        ctx.cq.load_table(table).await
+    }
+
+    #[inline]
+    async fn schema_map(&self) -> HashMap<String, arrow::datatypes::SchemaRef> {
+        let ctx = self.read().await;
+        ctx.cq.schema_map().clone()
+    }
+
+    #[inline]
+    async fn query_graphql(
+        &self,
+        query: &str,
+    ) -> Result<Vec<arrow::record_batch::RecordBatch>, QueryError> {
+        let ctx = self.read().await;
+        ctx.cq.query_graphql(query).await
+    }
+
+    #[inline]
+    async fn query_sql(
+        &self,
+        query: &str,
+    ) -> Result<Vec<arrow::record_batch::RecordBatch>, QueryError> {
+        let ctx = self.read().await;
+        ctx.cq.query_sql(query).await
+    }
+
+    #[inline]
+    async fn query_rest_table(
+        &self,
+        table_name: &str,
+        params: &HashMap<String, String>,
+    ) -> Result<Vec<arrow::record_batch::RecordBatch>, QueryError> {
+        let ctx = self.read().await;
+        ctx.cq.query_rest_table(table_name, params).await
     }
 }
 
@@ -155,10 +206,10 @@ pub fn encode_record_batches(
 }
 
 pub mod graphql;
+pub mod register;
 pub mod rest;
 pub mod routes;
 pub mod schema;
 pub mod sql;
-pub mod register;
 
 pub use routes::register_app_routes;

--- a/roapi-http/src/api/rest.rs
+++ b/roapi-http/src/api/rest.rs
@@ -6,10 +6,10 @@ use axum::response::IntoResponse;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use super::HandlerCtxType;
+use super::HandlerCtx;
 
-pub async fn get_table(
-    Extension(ctx): extract::Extension<Arc<HandlerCtxType>>,
+pub async fn get_table<H: HandlerCtx>(
+    Extension(ctx): extract::Extension<Arc<H>>,
     headers: HeaderMap,
     extract::Path(table_name): extract::Path<String>,
     extract::Query(params): extract::Query<HashMap<String, String>>,

--- a/roapi-http/src/api/schema.rs
+++ b/roapi-http/src/api/schema.rs
@@ -4,10 +4,10 @@ use axum::extract;
 use axum::response::IntoResponse;
 use std::sync::Arc;
 
-use super::HandlerCtxType;
+use super::HandlerCtx;
 
-pub async fn schema(
-    state: extract::Extension<Arc<HandlerCtxType>>,
+pub async fn schema<H: HandlerCtx>(
+    state: extract::Extension<Arc<H>>,
 ) -> Result<impl IntoResponse, ApiErrResp> {
     let ctx = state.0;
     let schema = ctx.schema_map().await;
@@ -17,8 +17,8 @@ pub async fn schema(
     Ok(bytes_to_json_resp(payload))
 }
 
-pub async fn get_by_table_name(
-    state: extract::Extension<Arc<HandlerCtxType>>,
+pub async fn get_by_table_name<H: HandlerCtx>(
+    state: extract::Extension<Arc<H>>,
     extract::Path(table_name): extract::Path<String>,
 ) -> Result<impl IntoResponse, ApiErrResp> {
     let ctx = state.0;

--- a/roapi-http/src/api/sql.rs
+++ b/roapi-http/src/api/sql.rs
@@ -7,10 +7,10 @@ use std::sync::Arc;
 use crate::api::{encode_record_batches, encode_type_from_hdr};
 use crate::error::ApiErrResp;
 
-use super::HandlerCtxType;
+use super::HandlerCtx;
 
-pub async fn post(
-    state: extract::Extension<Arc<HandlerCtxType>>,
+pub async fn post<H: HandlerCtx>(
+    state: extract::Extension<Arc<H>>,
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<impl IntoResponse, ApiErrResp> {

--- a/roapi-http/src/config.rs
+++ b/roapi-http/src/config.rs
@@ -10,7 +10,8 @@ use std::fs;
 pub struct Config {
     pub addr: Option<String>,
     pub tables: Vec<TableSource>,
-    pub read_only: bool,
+    #[serde(default)]
+    pub disable_read_only: bool,
 }
 
 fn table_arg() -> clap::Arg<'static> {
@@ -36,14 +37,12 @@ fn address_arg() -> clap::Arg<'static> {
 }
 
 fn read_only_arg() -> clap::Arg<'static> {
-    clap::Arg::new("read-only")
-        .help("Start roapi-http in read-only mode")
+    clap::Arg::new("disable-read-only")
+        .help("Start roapi-http in read write mode")
         .required(false)
-        .takes_value(true)
-        .default_value("true")
-        .value_name("BOOLEAN")
-        .long("read-only")
-        .short('r')
+        .takes_value(false)
+        .long("disable-read-only")
+        .short('d')
 }
 
 fn config_arg() -> clap::Arg<'static> {
@@ -86,7 +85,9 @@ pub fn get_configuration() -> Result<Config, anyhow::Error> {
         config.addr = Some(addr.to_string());
     }
 
-    config.read_only = matches.value_of("read-only").unwrap().parse::<bool>()?;
+    if matches.is_present("disable-read-only") {
+        config.disable_read_only = true;
+    }
 
     Ok(config)
 }

--- a/roapi-http/src/error.rs
+++ b/roapi-http/src/error.rs
@@ -93,7 +93,7 @@ impl ApiErrResp {
         Self {
             code: http::StatusCode::FORBIDDEN,
             error: "read_only_mode".to_string(),
-            message: "Current is in read-only mode".to_string(),
+            message: "Write operation is not allowed in read-only mode".to_string(),
         }
     }
 


### PR DESCRIPTION
We can avoid runtime enum matching overhead by introducing a HandlerCtx trait